### PR TITLE
Fixing installation problems and general updating of install.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+0.6
+----
+ * Doxygen now automatically generates html and man pages.
+ * Fixed bug where docs installing to build location was causing conflicts.
+   Now installed to /usr/local/share/doc/lcdapi per convention.
+ * Includes now install correctly to /usr/local/include/lcdapi.
+ * Man pages now install correctly to /usr/local/man/man3.
+ * Examples now install to /usr/local/share/lcdapi/examples.
+ * Omitted make and doxygen setup files from install.
+ * Doxygen now assumes that dot is in the path (instead of
+   at hard-coded location).
+
 0.5
 ----
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = docs
+
 lib_LTLIBRARIES = liblcdapi.la
 liblcdapi_la_SOURCES = \
 	lcdapi/api/LCDBar.cpp \
@@ -70,13 +72,12 @@ liblcdapi_la_CXXFLAGS = \
 
 ACLOCAL_AMFLAGS = -I m4
 
-docsdir = $(top_srcdir)/docs
-exampledir = $(top_srcdir)/example
+docsdir = $(datarootdir)/doc/$(PACKAGE)
+exampledir = $(pkgdatadir)/examples
+
+htmldocs := $(shell find docs/html -mindepth 1)
+
 dist_docs_DATA = \
-	docs/Makefile.am \
-	docs/Makefile.in \
-	docs/Doxyfile.in
+	$(htmldocs)
 dist_example_DATA = \
-	example/client.cpp \
-	example/Makefile.am \
-	example/Makefile.in
+	example/client.cpp

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([lcdapi], [0.5], [spdawson@gmail.com])
+AC_INIT([lcdapi], [0.6], [spdawson@gmail.com])
 AC_CONFIG_SRCDIR([lcdapi/api/LCDConnection.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,11 +1,14 @@
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = @PACKAGE_NAME@
 PROJECT_NUMBER         = @PACKAGE_VERSION@
-OUTPUT_DIRECTORY       = 
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       =
+CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English
-USE_WINDOWS_ENCODING   = NO
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = NO
 ABBREVIATE_BRIEF       = "The $name class" \
@@ -22,18 +25,33 @@ ABBREVIATE_BRIEF       = "The $name class" \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = YES
 FULL_PATH_NAMES        = NO
-STRIP_FROM_PATH        = 
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
+QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = YES
-DETAILS_AT_TOP         = YES
 INHERIT_DOCS           = YES
-DISTRIBUTE_GROUP_DOC   = NO
+SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 8
-ALIASES                = 
+ALIASES                =
+TCL_SUBST              =
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+EXTENSION_MAPPING      =
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
 SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+SYMBOL_CACHE_SIZE      = 0
+LOOKUP_CACHE_SIZE      = 0
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
@@ -41,6 +59,8 @@ EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = NO
 EXTRACT_STATIC         = NO
 EXTRACT_LOCAL_CLASSES  = NO
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
 HIDE_UNDOC_MEMBERS     = YES
 HIDE_UNDOC_CLASSES     = YES
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -49,17 +69,27 @@ INTERNAL_DOCS          = NO
 CASE_SENSE_NAMES       = YES
 HIDE_SCOPE_NAMES       = YES
 SHOW_INCLUDE_FILES     = YES
+FORCE_LOCAL_INCLUDES   = NO
 INLINE_INFO            = NO
 SORT_MEMBER_DOCS       = YES
 SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
 SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
 GENERATE_TODOLIST      = YES
 GENERATE_TESTLIST      = YES
 GENERATE_BUGLIST       = YES
 GENERATE_DEPRECATEDLIST= YES
-ENABLED_SECTIONS       = 
+ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = NO
+SHOW_DIRECTORIES       = NO
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
 #---------------------------------------------------------------------------
 # configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
@@ -67,24 +97,29 @@ QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
 WARN_FORMAT            = "$file:$line: $text"
-WARN_LOGFILE           = 
+WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = @top_srcdir@
+INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.cpp \
                          *.h
 RECURSIVE              = YES
-EXCLUDE                = 
+EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = 
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           = ../example/
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = 
-INPUT_FILTER           = 
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
 #---------------------------------------------------------------------------
 # configuration options related to source browsing
 #---------------------------------------------------------------------------
@@ -93,33 +128,66 @@ INLINE_SOURCES         = NO
 STRIP_CODE_COMMENTS    = YES
 REFERENCED_BY_RELATION = NO
 REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
 #---------------------------------------------------------------------------
 # configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = YES
 COLS_IN_ALPHA_INDEX    = 5
-IGNORE_PREFIX          = 
+IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output
 #---------------------------------------------------------------------------
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
 HTML_FILE_EXTENSION    = .html
-HTML_HEADER            = 
-HTML_FOOTER            = 
-HTML_STYLESHEET        = 
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = YES
 HTML_ALIGN_MEMBERS     = YES
+HTML_DYNAMIC_SECTIONS  = NO
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
 GENERATE_HTMLHELP      = NO
-CHM_FILE               = 
-HHC_LOCATION           = 
+CHM_FILE               =
+HHC_LOCATION           =
 GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = YES
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
 DISABLE_INDEX          = NO
-ENUM_VALUES_PER_LINE   = 4
 GENERATE_TREEVIEW      = NO
+ENUM_VALUES_PER_LINE   = 4
+USE_INLINE_TREES       = NO
 TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+USE_MATHJAX            = NO
+MATHJAX_RELPATH        = http://www.mathjax.org/mathjax
+MATHJAX_EXTENSIONS     =
+SEARCHENGINE           = NO
+SERVER_BASED_SEARCH    = NO
 #---------------------------------------------------------------------------
 # configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
@@ -129,12 +197,15 @@ LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4wide
-EXTRA_PACKAGES         = 
-LATEX_HEADER           = 
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
 PDF_HYPERLINKS         = NO
 USE_PDFLATEX           = NO
 LATEX_BATCHMODE        = NO
 LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
 #---------------------------------------------------------------------------
 # configuration options related to the RTF output
 #---------------------------------------------------------------------------
@@ -142,8 +213,8 @@ GENERATE_RTF           = NO
 RTF_OUTPUT             = rtf
 COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
-RTF_STYLESHEET_FILE    = 
-RTF_EXTENSIONS_FILE    = 
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
 #---------------------------------------------------------------------------
 # configuration options related to the man page output
 #---------------------------------------------------------------------------
@@ -156,8 +227,8 @@ MAN_LINKS              = NO
 #---------------------------------------------------------------------------
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
-XML_SCHEMA             = 
-XML_DTD                = 
+XML_SCHEMA             =
+XML_DTD                =
 XML_PROGRAMLISTING     = YES
 #---------------------------------------------------------------------------
 # configuration options for the AutoGen Definitions output
@@ -169,50 +240,57 @@ GENERATE_AUTOGEN_DEF   = NO
 GENERATE_PERLMOD       = NO
 PERLMOD_LATEX          = NO
 PERLMOD_PRETTY         = YES
-PERLMOD_MAKEVAR_PREFIX = 
+PERLMOD_MAKEVAR_PREFIX =
 #---------------------------------------------------------------------------
-# Configuration options related to the preprocessor   
+# Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = NO
 EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
-INCLUDE_PATH           = 
-INCLUDE_FILE_PATTERNS  = 
-PREDEFINED             = 
-EXPAND_AS_DEFINED      = 
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
-# Configuration::additions related to external references   
+# Configuration::additions related to external references
 #---------------------------------------------------------------------------
-TAGFILES               = 
-GENERATE_TAGFILE       = 
+TAGFILES               =
+GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
-# Configuration options related to the dot tool   
+# Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 CLASS_DIAGRAMS         = YES
+MSCGEN_PATH            =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
 CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
 UML_LOOK               = NO
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
 CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
 DOT_IMAGE_FORMAT       = png
-DOT_PATH               = /usr/local/bin
-DOTFILE_DIRS           = 
-MAX_DOT_GRAPH_WIDTH    = 1024
-MAX_DOT_GRAPH_HEIGHT   = 1024
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 1000
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = YES
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
-#---------------------------------------------------------------------------
-# Configuration::additions related to the search engine   
-#---------------------------------------------------------------------------
-SEARCHENGINE           = NO

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,9 +1,45 @@
 if HAVE_DOXYGEN
-directory = $(top_srcdir)/docs/man/man3/
+directory = $(top_srcdir)/docs/man/man3
 
-dist_man_MANS = $(directory)/man_page_1.3 $(directory)/man_page_2.3
-$(directory)/man_page_1.3: doxyfile.stamp
-$(directory)/man_page_2.3: doxyfile.stamp
+dist_man_MANS = $(directory)/constants.3 $(directory)/keys.3 $(directory)/lcdapi_LCDBar.3 $(directory)/lcdapi_LCDBigNumber.3 \
+	$(directory)/lcdapi_LCDCallback.3 $(directory)/lcdapi_LCDClient.3 $(directory)/lcdapi_LCDCpuSensor.3 $(directory)/lcdapi_LCDElement.3 \
+	$(directory)/lcdapi_LCDException.3 $(directory)/lcdapi_LCDFrame.3 $(directory)/lcdapi_LCDHorizontalBar.3 $(directory)/lcdapi_LCDIcon.3 \
+	$(directory)/lcdapi_LCDKdeMultimediaSensor.3 $(directory)/lcdapi_LCDLock.3 $(directory)/lcdapi_LCDMenuEventHandler.3 \
+	$(directory)/lcdapi_LCDMutex.3 $(directory)/lcdapi_LCDScreen.3 $(directory)/lcdapi_LCDScroller.3 $(directory)/lcdapi_LCDSensor.3 \
+	$(directory)/lcdapi_LCDSystemSensor.3 $(directory)/lcdapi_LCDText.3 $(directory)/lcdapi_LCDTimeSensor.3 $(directory)/lcdapi_LCDTitle.3 \
+	$(directory)/lcdapi_LCDVerticalBar.3 $(directory)/lcdapi_LCDWidget.3 $(directory)/main.3 $(directory)/menu_constants.3 $(directory)/menus.3 \
+	$(directory)/screen_constants.3 $(directory)/sensors.3 $(directory)/widgets.3
+$(directory)/constants.3: doxyfile.stamp
+$(directory)/keys.3: doxyfile.stamp
+$(directory)/lcdapi_LCDBar.3: doxyfile.stamp
+$(directory)/lcdapi_LCDBigNumber.3: doxyfile.stamp
+$(directory)/lcdapi_LCDCallback.3: doxyfile.stamp
+$(directory)/lcdapi_LCDClient.3: doxyfile.stamp
+$(directory)/lcdapi_LCDCpuSensor.3: doxyfile.stamp
+$(directory)/lcdapi_LCDElement.3: doxyfile.stamp
+$(directory)/lcdapi_LCDException.3: doxyfile.stamp
+$(directory)/lcdapi_LCDFrame.3: doxyfile.stamp
+$(directory)/lcdapi_LCDHorizontalBar.3: doxyfile.stamp
+$(directory)/lcdapi_LCDIcon.3: doxyfile.stamp
+$(directory)/lcdapi_LCDKdeMultimediaSensor.3: doxyfile.stamp
+$(directory)/lcdapi_LCDLock.3: doxyfile.stamp
+$(directory)/lcdapi_LCDMenuEventHandler.3: doxyfile.stamp
+$(directory)/lcdapi_LCDMutex.3: doxyfile.stamp
+$(directory)/lcdapi_LCDScreen.3: doxyfile.stamp
+$(directory)/lcdapi_LCDScroller.3: doxyfile.stamp
+$(directory)/lcdapi_LCDSensor.3: doxyfile.stamp
+$(directory)/lcdapi_LCDSystemSensor.3: doxyfile.stamp
+$(directory)/lcdapi_LCDText.3: doxyfile.stamp
+$(directory)/lcdapi_LCDTimeSensor.3: doxyfile.stamp
+$(directory)/lcdapi_LCDTitle.3: doxyfile.stamp
+$(directory)/lcdapi_LCDVerticalBar.3: doxyfile.stamp
+$(directory)/lcdapi_LCDWidget.3: doxyfile.stamp
+$(directory)/main.3: doxyfile.stamp
+$(directory)/menu_constants.3: doxyfile.stamp
+$(directory)/menus.3: doxyfile.stamp
+$(directory)/screen_constants.3: doxyfile.stamp
+$(directory)/sensors.3: doxyfile.stamp
+$(directory)/widgets.3: doxyfile.stamp
 
 doxyfile.stamp:
 	$(DOXYGEN) Doxyfile

--- a/lcdapi/include/LCDHeaders.h
+++ b/lcdapi/include/LCDHeaders.h
@@ -1,4 +1,4 @@
-/* Copyright 2012-2013 Simon Dawson <spdawson@gmail.com>
+/* Copyright 2012-2015 Simon Dawson <spdawson@gmail.com>
 
    This file is part of lcdapi.
 
@@ -48,17 +48,40 @@
  *
  * You can get the source from the following link:
  *
- * https://github.com/spdawson/lcdapi/tarball/v0.5
+ * https://github.com/spdawson/lcdapi/tarball/v0.6
  *
  * You can then unpack them with:
  * \code
- * tar xaf lcdapi-0.5.tar.gz
+ * tar xaf lcdapi-0.6.tar.gz
  * \endcode
- * Go into the new directory and type:
+ * Go into the new directory and execute the following commands:
  * \code
+ * libtoolize --force
+ * aclocal
+ * autoheader
+ * automake --force-missing --add-missing
+ * autoconf
+ * ./configure
  * make
+ * sudo make install
  * \endcode
- * You will then have the liblcdapi.so library in the lib directory.
+ * This will install the application to the following directories:
+ *
+ * <ul>
+ *   <li>/usr/local/lib: The shared library (liblcdapi.so).</li>
+ *   <li>/usr/local/include/lcdapi: The include (*.h) files for the library.</li>
+ *   <li>/usr/local/share/doc/lcdapi: The HTML documentation. Go to index.html for the root.</li>
+ *   <li>/usr/local/share/lcdapi/examples: The example application and Makefile.</li>
+ * </ul>
+ *
+ * Man pages can also be accessed for many classes in the application by typing: man <classname>. man main is the main main page for lcdapi.
+ *
+ * \section uninstall Uninstallation
+ *
+ * From the source folder, run:
+ * \code
+ * sudo make uninstall
+ * \endcode
  *
  * \section use Usage
  *
@@ -69,9 +92,8 @@
  *
  * To compile client.cpp for example, you should use these commands on a GNU/Linux system:
  * \code
- * export LCD_API_DIR=/where/LCD_API/is
- * export LD_LIBRARY_PATH=$LCD_API_DIR/lib:$LD_LIBRARY_PATH
- * g++ -o client client.cpp -I$LCD_API_DIR/include -L$LCD_API_DIR/lib -llcdapi -lpthread
+ * export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ * g++ -o client client.cpp -I/usr/local/include/lcdapi -L/usr/local/lib -llcdapi -lpthread
  * \endcode
  * There may have some differences on other systems.
  *  For example you must add -lsocket on Solaris.


### PR DESCRIPTION
Fixed problem with docs installing to source_location/docs (files already exist).
Includes now install to /usr/local/includes.
Doxygen now runs automatically, generating docs in docs/html and docs/man/man3. These are then copied to /usr/local/share/doc/lcdapi and /usr/local/share/man/man3, respectively.
Examples now install to /usr/local/share/lcdapi/examples.
Fixed problem with location of DOT for doxygen (removed absolute path - now assumes dot is in user's path).
Updated docs/Doxyfile.in with macros from doxygen 1.7.6.1 (using doxygen -u).
Documentation updated to reflect new version (0.6) and new install locations.
